### PR TITLE
Add ERP as a content source for Standard Codes

### DIFF
--- a/scripts/build-content.ts
+++ b/scripts/build-content.ts
@@ -181,7 +181,8 @@ async function buildContent() {
     const standardCodesRecords = await fetchDataWithFallback(
       STANDARD_CODES_CSV_PATH,
       'StandardCodes',
-      'GOOGLE_SHEET_TAB_STANDARD_CODES'
+      'GOOGLE_SHEET_TAB_STANDARD_CODES',
+      'standard-codes'
     );
     const publicationsRecords = await fetchDataWithFallback(
       PUBLICATIONS_CSV_PATH,

--- a/scripts/parsers/data-source.ts
+++ b/scripts/parsers/data-source.ts
@@ -5,19 +5,41 @@
 
 import { parseCSVFile, CSVRecord } from './csv-parser.js';
 import { fetchSheetData, shouldUseSheets, getSheetTabName } from './google-sheets-parser.js';
+import { fetchErpContent, shouldUseErp } from './erp-content-parser.js';
 
 /**
- * Fetch data from Google Sheets or CSV with automatic fallback
+ * Fetch data from ERP-published content, Google Sheets, or CSV — in that
+ * priority order, each falling through to the next on failure.
  * @param csvPath - Path to local CSV file
  * @param sheetTabName - Default Google Sheets tab name
  * @param sheetTabEnvVar - Optional environment variable for custom tab name
+ * @param erpContentType - Optional ERP-published content type key (e.g. 'standard-codes').
+ *   Only content types that have actually migrated off Sheets pass this — omitting it
+ *   leaves a call site on the existing Sheets/CSV path with no behavior change. Gated by
+ *   its own ERP_CONTENT_ENABLED flag (see erp-content-parser.ts), not CONTENT_SOURCE_MODE,
+ *   so ERP-sourced and Sheets-sourced content types can coexist during the phased migration.
  * @returns Array of records (key-value pairs)
  */
 export async function fetchDataWithFallback(
   csvPath: string,
   sheetTabName: string,
-  sheetTabEnvVar?: string
+  sheetTabEnvVar?: string,
+  erpContentType?: string
 ): Promise<CSVRecord[]> {
+  // ERP-published content takes priority when both ERP_CONTENT_ENABLED and
+  // a content type for this call site are configured. Falls through to CSV
+  // on failure, same reasoning as the Sheets path below: a broken publish
+  // should degrade the build to stale content, never break it outright.
+  if (shouldUseErp() && erpContentType) {
+    try {
+      return await fetchErpContent(erpContentType);
+    } catch (error) {
+      console.warn('⚠️  Failed to fetch ERP-published content, falling back to local CSV');
+      console.error(error instanceof Error ? error.message : error);
+      // Fall through to CSV
+    }
+  }
+
   // Check if we should use Google Sheets
   if (shouldUseSheets()) {
     const tabName = getSheetTabName(sheetTabName, sheetTabEnvVar);

--- a/scripts/parsers/erp-content-parser.ts
+++ b/scripts/parsers/erp-content-parser.ts
@@ -1,0 +1,83 @@
+/**
+ * ERP Content Parser
+ *
+ * Fetches published-content JSON snapshots that ERPNext (eng_lab_suite's
+ * website_publish.py) pushes to Cloudflare R2, replacing what used to be a
+ * live Google Sheets API call for content types that have moved to ERP as
+ * their source of truth (Standard Codes first).
+ *
+ * ERPNext pushes, this only ever pulls: a plain, unauthenticated GET
+ * against the same public R2 bucket the build already trusts for media, at
+ * content/erp/{contentType}.json. No new credentials, and no direct call
+ * to ERPNext itself — the public build should never be a live inbound
+ * request against production ERP.
+ *
+ * @module scripts/parsers/erp-content-parser
+ */
+
+import { CSVRecord } from './csv-parser.js';
+
+/**
+ * Fetch a published content-type snapshot from R2.
+ *
+ * Returns rows in the same shape parseCSVFile() and the Google Sheets
+ * parser already return — plain {header: value} objects — so every
+ * downstream content parser (parseStandardCodes, etc.) needs zero changes
+ * to consume this. The ERP-side serializer is responsible for producing
+ * field names that already match what those parsers expect.
+ *
+ * @param contentType - Content type key, e.g. 'standard-codes'
+ * @returns Array of row objects
+ */
+export async function fetchErpContent(contentType: string): Promise<CSVRecord[]> {
+  const base = process.env.NEXT_PUBLIC_R2_BASE_URL;
+  if (!base) {
+    throw new Error(
+      'NEXT_PUBLIC_R2_BASE_URL not set!\n' +
+      'ERP content mode (CONTENT_SOURCE_MODE=erp) reuses the same R2 base URL already used for media.'
+    );
+  }
+
+  const url = `${base.replace(/\/$/, '')}/content/erp/${contentType}.json`;
+
+  console.log(`📊 Fetching ERP-published content: "${contentType}"`);
+
+  let response: Response;
+  try {
+    response = await fetch(url);
+  } catch (error) {
+    throw new Error(
+      `Failed to reach R2 for ERP content "${contentType}"\n` +
+      `URL: ${url}\n` +
+      `${error instanceof Error ? error.message : error}`
+    );
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `ERP content fetch failed for "${contentType}": HTTP ${response.status}\n` +
+      `URL: ${url}`
+    );
+  }
+
+  const data = (await response.json()) as CSVRecord[];
+  console.log(`✅ Fetched ${data.length} rows from ERP-published content ("${contentType}")`);
+  return data;
+}
+
+/**
+ * Check if we should use ERP-published content as the data source.
+ *
+ * Deliberately its own flag, not a third CONTENT_SOURCE_MODE value —
+ * migration is phased (one content type at a time over several PRs), and
+ * CONTENT_SOURCE_MODE=sheets/csv already governs every call site that
+ * hasn't migrated yet. If ERP were a third exclusive mode value, turning
+ * it on would silently stop fetching everything still on Sheets for the
+ * entire migration window. This way both stay on simultaneously:
+ * CONTENT_SOURCE_MODE=sheets and ERP_CONTENT_ENABLED=true together mean
+ * "Standard Codes (and whatever else has migrated) comes from ERP,
+ * everything else still comes from Sheets, same as today."
+ */
+export function shouldUseErp(): boolean {
+  return process.env.ERP_CONTENT_ENABLED === 'true';
+}


### PR DESCRIPTION
## Summary

nswebsite-side companion to `eng_lab_suite#76` and `nserp#12` — adds ERP-published content (pushed to Cloudflare R2) as a source `fetchDataWithFallback` can pull from, wired up for Standard Codes only.

## What's here

- `scripts/parsers/erp-content-parser.ts` — `fetchErpContent(contentType)`: a plain, unauthenticated `GET` against `content/erp/{contentType}.json` on the same R2 bucket the build already trusts for media. No new credentials needed — reuses `NEXT_PUBLIC_R2_BASE_URL`, already set today.
- `scripts/parsers/data-source.ts` — `fetchDataWithFallback` grows a 4th optional param (`erpContentType`), checked before the existing Sheets branch, falling through to CSV on failure exactly like Sheets does today (a broken publish degrades to stale content, never breaks the build).
- `scripts/build-content.ts` — only the Standard Codes call site passes `erpContentType: 'standard-codes'`. Every other content type's call site is unchanged and unaffected.

**One real design correction made while writing this**: I initially reused `CONTENT_SOURCE_MODE=erp` as a third exclusive mode value (matching how the architecture doc originally described it), then realized that's wrong for a phased migration — since `shouldUseSheets()` checks for the literal value `'sheets'`, setting the mode to `'erp'` would silently stop fetching *every other* Sheets-backed content type (Team, Projects, FAQ, etc.) for the entire migration window, not just Standard Codes. Fixed by gating ERP fetching on its own `ERP_CONTENT_ENABLED` flag instead, so `CONTENT_SOURCE_MODE=sheets` + `ERP_CONTENT_ENABLED=true` can run together — Standard Codes comes from ERP, everything else keeps coming from Sheets exactly as it does today.

## Not yet wired up

- No CI workflow sets `ERP_CONTENT_ENABLED` yet — this is inert until `eng_lab_suite#76` + `nserp#12` are merged, real R2 credentials are provisioned, and there's actual published content at `content/erp/standard-codes.json` to fetch.
- `deploy-dev.yml` doesn't need Google Sheets credentials removed yet either — Standard Codes should get proven working in ERP mode first, Sheets stays the fallback/comparison until then.

## Test plan / verification caveat

**npm is broken in the environment this was written in** (stale WSL path baked into the global npm shim — `Cannot find module '\\wsl.localhost\Ubuntu\...\npm'`), so I could not run this through the project's real `tsc`/`npm run build:content`. I verified with `node --experimental-strip-types --check` on all three touched files, which catches syntax errors but not full type errors.

- [x] `node --experimental-strip-types --check` on all 3 files — clean
- [x] Confirmed `tsconfig.json`'s `lib: ["dom", ...]` includes the `fetch`/`Response` globals `erp-content-parser.ts` uses
- [ ] **Please run a real typecheck (`tsc --noEmit`) before merging** — I could not verify this myself
- [ ] End-to-end once the ERP side is live: set `ERP_CONTENT_ENABLED=true` in a dev build, confirm `/elibrary` still renders Standard Codes correctly from the R2-sourced JSON

Ritika — flagging this one for you specifically since you own this pipeline; the `erp` branch in `fetchDataWithFallback` is structurally identical to the Sheets↔CSV fallback you already built, just a third source. Happy to walk through the design reasoning (especially the `ERP_CONTENT_ENABLED` vs. `CONTENT_SOURCE_MODE` correction above) if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)